### PR TITLE
V2025.08.17 Optional security adjustments

### DIFF
--- a/apicache/Dockerfile
+++ b/apicache/Dockerfile
@@ -7,13 +7,27 @@ RUN apk add --no-cache \
     libffi-dev \
     && rm -rf /var/cache/apk/*
 
+
+# Create a non-root user and group
+RUN addgroup -S apigroup && adduser -S apiuser -G apigroup
+
+# Set working directory
 WORKDIR /code
 
+# Copy requirements
 COPY ./apicache/requirements.txt /code/requirements.txt
 
 RUN pip install --no-cache-dir --upgrade -r /code/requirements.txt
 RUN pip install setuptools
 
+# Copy application code
 COPY ./apicache/app /code/app
 
-CMD ["gunicorn", "--conf", "app/gunicorn_conf.py", "--bind", "0.0.0.0:80", "app.main:app"] 
+# Change ownership of the working directory
+RUN chown -R apiuser:apigroup /code
+
+# Switch to non-root user
+USER apiuser
+
+# Command
+CMD ["gunicorn", "--config", "app/gunicorn_conf.py", "--bind", "0.0.0.0:8080", "app.main:app"]

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,2 +1,2 @@
 FROM nginxinc/nginx-unprivileged:alpine
-COPY public.conf /etc/nginx/conf.d/public.conf
+COPY ./nginx/public.conf /etc/nginx/conf.d/public.conf

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,2 +1,2 @@
-FROM nginx:mainline-perl
-COPY ./nginx/public.conf /etc/nginx/conf.d/public.conf
+FROM nginxinc/nginx-unprivileged:alpine
+COPY public.conf /etc/nginx/conf.d/public.conf

--- a/nginx/public.conf
+++ b/nginx/public.conf
@@ -45,11 +45,11 @@ server {
     }
 
     location /api/ {
-        proxy_pass http://app:80/api/;
+        proxy_pass http://app:8080/api/;
         proxy_set_header Host $host; 
     }
     location /olly/ {
-        proxy_pass http://app:80/olly/;
+        proxy_pass http://app:8080/olly/;
         proxy_set_header Host $host; 
     }
 


### PR DESCRIPTION
Optional security adjustments
- Change the apicache port from 80 to 8080 and run the container unprivileged.
- Change to nginx unprivileged alpine image to mitigate vulnerabilities and run the container unprivileged.